### PR TITLE
build(docker): update python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.13-slim-bookworm
 
 RUN apt-get update
 RUN apt-get -y install jq


### PR DESCRIPTION
- update python base image from 3.11-slim-buster to 3.13-slim-bookworm
- this updates the python version and the underlying distribution